### PR TITLE
Skip gpg sign while travis install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,6 @@ jdk:
   - openjdk7
   - oraclejdk8
 
+install: mvn clean package install -DskipTests -Dgpg.skip
 script:
   - mvn test

--- a/pom.xml
+++ b/pom.xml
@@ -142,32 +142,31 @@
         </executions>
       </plugin>
 
-      <!-- Uncomment the following plugins to release to mvn central -->
-      <!-- <plugin> -->
-      <!--   <groupId>org.apache.maven.plugins</groupId> -->
-      <!--   <artifactId>maven-gpg-plugin</artifactId> -->
-      <!--   <version>1.5</version> -->
-      <!--   <executions> -->
-      <!--     <execution> -->
-      <!--       <id>sign-artifacts</id> -->
-      <!--       <phase>verify</phase> -->
-      <!--       <goals> -->
-      <!--         <goal>sign</goal> -->
-      <!--       </goals> -->
-      <!--     </execution> -->
-      <!--   </executions> -->
-      <!-- </plugin> -->
-      <!-- <plugin> -->
-      <!--   <groupId>org.sonatype.plugins</groupId> -->
-      <!--   <artifactId>nexus-staging-maven-plugin</artifactId> -->
-      <!--   <version>1.6.7</version> -->
-      <!--   <extensions>true</extensions> -->
-      <!--   <configuration> -->
-      <!--     <serverId>ossrh</serverId> -->
-      <!--     <nexusUrl>https://oss.sonatype.org/</nexusUrl> -->
-      <!--     <autoReleaseAfterClose>true</autoReleaseAfterClose> -->
-      <!--   </configuration> -->
-      <!-- </plugin> -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-gpg-plugin</artifactId>
+        <version>1.5</version>
+        <executions>
+          <execution>
+            <id>sign-artifacts</id>
+            <phase>verify</phase>
+             <goals>
+               <goal>sign</goal>
+             </goals>
+           </execution>
+         </executions>
+       </plugin>
+       <plugin>
+         <groupId>org.sonatype.plugins</groupId>
+         <artifactId>nexus-staging-maven-plugin</artifactId>
+         <version>1.6.7</version>
+         <extensions>true</extensions>
+         <configuration>
+           <serverId>ossrh</serverId>
+           <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+           <autoReleaseAfterClose>true</autoReleaseAfterClose>
+         </configuration>
+       </plugin>
 
     </plugins>
   </build>


### PR DESCRIPTION
With this change,  we don't need to uncomment maven-gpg-plugin everytime we need to release to maven