### PR TITLE
Install openjdk6 for travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,22 @@
 language: java
 
+addons:
+  apt:
+    packages:
+      - openjdk-6-jdk
+
 jdk:
   - openjdk6
   - openjdk7
   - oraclejdk8
 
-install: mvn clean package install -DskipTests -Dgpg.skip
+install:
+  - echo "Downloading Maven 3.0";
+  - wget https://archive.apache.org/dist/maven/binaries/apache-maven-3.0-bin.zip || travis_terminate 1
+  - unzip -qq apache-maven-3.0-bin.zip || travis_terminate 1
+  - export M2_HOME=$PWD/apache-maven-3.0
+  - export PATH=$M2_HOME/bin:$PATH
+  - mvn -version
+  - mvn clean package install -DskipTests -Dgpg.skip
 script:
   - mvn test


### PR DESCRIPTION
Fix broken openjdk6 travis build, see https://github.com/travis-ci/travis-ci/issues/8452

# Testing Done
Travis build passed: https://travis-ci.org/aliyun/fc-java-sdk/jobs/276715544